### PR TITLE
feat: add multi-port support per service

### DIFF
--- a/examples/multi-port/README.md
+++ b/examples/multi-port/README.md
@@ -1,0 +1,28 @@
+# multi-port
+
+Multiple ports per service example. Each port gets its own environment variable and proxy route.
+
+## Usage
+
+```bash
+# Start with dockportless (auto port + proxy)
+dockportless run multi-port docker compose up
+
+# Access via indexed URLs
+curl http://0.web.multi-port.localhost:7355/   # -> WEB_PORT_0 (port 80)
+curl http://1.web.multi-port.localhost:7355/   # -> WEB_PORT_1 (port 443)
+curl http://0.api.multi-port.localhost:7355/   # -> API_PORT_0 (port 5678)
+
+# SERVICE_PORT is an alias for SERVICE_PORT_0
+# WEB_PORT == WEB_PORT_0, API_PORT == API_PORT_0
+```
+
+## Without dockportless
+
+```bash
+# Falls back to default ports
+docker compose up
+curl http://localhost:8080/
+curl http://localhost:8443/
+curl http://localhost:5678/
+```

--- a/examples/multi-port/compose.yml
+++ b/examples/multi-port/compose.yml
@@ -1,0 +1,12 @@
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "${WEB_PORT_0:-8080}:80"
+      - "${WEB_PORT_1:-8443}:443"
+
+  api:
+    image: hashicorp/http-echo
+    command: ["-text=hello from api", "-listen=:5678"]
+    ports:
+      - "${API_PORT_0:-5678}:5678"

--- a/src/compose.zig
+++ b/src/compose.zig
@@ -26,8 +26,13 @@ pub fn findComposeFile(dir: std.fs.Dir) ComposeError![]const u8 {
     return ComposeError.FileNotFound;
 }
 
-/// Parse a compose file and return a list of service names.
-pub fn parseServices(allocator: Allocator, dir: std.fs.Dir, file_path: []const u8) ![]const []const u8 {
+pub const ServiceInfo = struct {
+    name: []const u8,
+    port_count: usize,
+};
+
+/// Parse a compose file and return a list of services with port counts.
+pub fn parseServices(allocator: Allocator, dir: std.fs.Dir, file_path: []const u8) ![]const ServiceInfo {
     const source = dir.readFileAlloc(allocator, file_path, 1024 * 1024) catch {
         return ComposeError.FileNotFound;
     };
@@ -36,8 +41,8 @@ pub fn parseServices(allocator: Allocator, dir: std.fs.Dir, file_path: []const u
     return parseServicesFromSource(allocator, source);
 }
 
-/// Extract service names from YAML source.
-fn parseServicesFromSource(allocator: Allocator, source: []const u8) ![]const []const u8 {
+/// Extract service info (name + port count) from YAML source.
+fn parseServicesFromSource(allocator: Allocator, source: []const u8) ![]const ServiceInfo {
     var doc = yaml.Yaml{ .source = source };
     defer doc.deinit(allocator);
 
@@ -56,9 +61,23 @@ fn parseServicesFromSource(allocator: Allocator, source: []const u8) ![]const []
     const services_map = services_value.asMap() orelse return ComposeError.NoServicesFound;
 
     const keys = services_map.keys();
-    const result = try allocator.alloc([]const u8, keys.len);
-    for (keys, 0..) |key, i| {
-        result[i] = try allocator.dupe(u8, key);
+    const values = services_map.values();
+    const result = try allocator.alloc(ServiceInfo, keys.len);
+    for (keys, values, 0..) |key, value, i| {
+        var port_count: usize = 1; // default: 1 port per service
+        if (value.asMap()) |svc_map| {
+            if (svc_map.get("ports")) |ports_value| {
+                if (ports_value.asList()) |ports_list| {
+                    if (ports_list.len > 0) {
+                        port_count = ports_list.len;
+                    }
+                }
+            }
+        }
+        result[i] = .{
+            .name = try allocator.dupe(u8, key),
+            .port_count = port_count,
+        };
     }
 
     return result;
@@ -91,9 +110,9 @@ pub fn extractComposeFilesFromArgs(allocator: Allocator, cmd_args: []const []con
     return result;
 }
 
-pub fn freeServices(allocator: Allocator, services: []const []const u8) void {
+pub fn freeServices(allocator: Allocator, services: []const ServiceInfo) void {
     for (services) |service| {
-        allocator.free(service);
+        allocator.free(service.name);
     }
     allocator.free(services);
 }
@@ -114,8 +133,10 @@ test "parseServicesFromSource: basic compose file" {
     defer freeServices(allocator, services);
 
     try std.testing.expectEqual(@as(usize, 2), services.len);
-    try std.testing.expectEqualStrings("web", services[0]);
-    try std.testing.expectEqualStrings("api", services[1]);
+    try std.testing.expectEqualStrings("web", services[0].name);
+    try std.testing.expectEqual(@as(usize, 1), services[0].port_count);
+    try std.testing.expectEqualStrings("api", services[1].name);
+    try std.testing.expectEqual(@as(usize, 1), services[1].port_count);
 }
 
 test "parseServicesFromSource: no services key" {
@@ -163,7 +184,33 @@ test "parseServicesFromSource: single service" {
     defer freeServices(allocator, services);
 
     try std.testing.expectEqual(@as(usize, 1), services.len);
-    try std.testing.expectEqualStrings("db", services[0]);
+    try std.testing.expectEqualStrings("db", services[0].name);
+    try std.testing.expectEqual(@as(usize, 1), services[0].port_count);
+}
+
+test "parseServicesFromSource: service with multiple ports" {
+    const source =
+        \\services:
+        \\  web:
+        \\    image: nginx
+        \\    ports:
+        \\      - "8080:80"
+        \\      - "8443:443"
+        \\  api:
+        \\    image: node
+        \\    ports:
+        \\      - "3000:3000"
+    ;
+
+    const allocator = std.testing.allocator;
+    const services = try parseServicesFromSource(allocator, source);
+    defer freeServices(allocator, services);
+
+    try std.testing.expectEqual(@as(usize, 2), services.len);
+    try std.testing.expectEqualStrings("web", services[0].name);
+    try std.testing.expectEqual(@as(usize, 2), services[0].port_count);
+    try std.testing.expectEqualStrings("api", services[1].name);
+    try std.testing.expectEqual(@as(usize, 1), services[1].port_count);
 }
 
 // --- extractComposeFilesFromArgs tests ---

--- a/src/executor.zig
+++ b/src/executor.zig
@@ -3,12 +3,11 @@ const posix = std.posix;
 
 const Allocator = std.mem.Allocator;
 
-/// Convert a service name to an environment variable name.
+/// Convert a service name to an uppercase env var prefix.
 /// - Convert to uppercase
 /// - Replace hyphens with underscores
-/// - Append _PORT suffix
-pub fn serviceNameToEnvVar(allocator: Allocator, service_name: []const u8) ![]u8 {
-    const result = try allocator.alloc(u8, service_name.len + "_PORT".len);
+fn serviceNameToUpperCase(allocator: Allocator, service_name: []const u8) ![]u8 {
+    const result = try allocator.alloc(u8, service_name.len);
 
     for (service_name, 0..) |c, i| {
         result[i] = switch (c) {
@@ -18,31 +17,56 @@ pub fn serviceNameToEnvVar(allocator: Allocator, service_name: []const u8) ![]u8
         };
     }
 
-    @memcpy(result[service_name.len..], "_PORT");
-
     return result;
 }
 
-pub const ServicePort = struct {
+/// Convert a service name to a base environment variable name (no index).
+/// e.g. "web" -> "WEB_PORT"
+pub fn serviceNameToBaseEnvVar(allocator: Allocator, service_name: []const u8) ![]u8 {
+    const upper = try serviceNameToUpperCase(allocator, service_name);
+    defer allocator.free(upper);
+
+    return std.fmt.allocPrint(allocator, "{s}_PORT", .{upper});
+}
+
+/// Convert a service name to an indexed environment variable name.
+/// e.g. ("web", 0) -> "WEB_PORT_0"
+pub fn serviceNameToEnvVar(allocator: Allocator, service_name: []const u8, index: usize) ![]u8 {
+    const upper = try serviceNameToUpperCase(allocator, service_name);
+    defer allocator.free(upper);
+
+    return std.fmt.allocPrint(allocator, "{s}_PORT_{d}", .{ upper, index });
+}
+
+pub const ServicePorts = struct {
     service_name: []const u8,
-    port: u16,
+    ports: []const u16,
 };
 
 /// Set environment variables and execute the user command as a child process, waiting for it to finish.
-pub fn exec(allocator: Allocator, argv: []const []const u8, services: []const ServicePort) !std.process.Child.Term {
+pub fn exec(allocator: Allocator, argv: []const []const u8, services: []const ServicePorts) !std.process.Child.Term {
     // Copy current environment
     var env_map = try std.process.getEnvMap(allocator);
     defer env_map.deinit();
 
     // Add service port environment variables
     for (services) |svc| {
-        const env_name = try serviceNameToEnvVar(allocator, svc.service_name);
-        defer allocator.free(env_name);
+        for (svc.ports, 0..) |svc_port, idx| {
+            const env_name = try serviceNameToEnvVar(allocator, svc.service_name, idx);
+            defer allocator.free(env_name);
 
-        var port_buf: [5]u8 = undefined;
-        const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{svc.port}) catch unreachable;
+            var port_buf: [5]u8 = undefined;
+            const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{svc_port}) catch unreachable;
 
-        try env_map.put(env_name, port_str);
+            try env_map.put(env_name, port_str);
+
+            // SERVICE_PORT alias for index 0
+            if (idx == 0) {
+                const alias = try serviceNameToBaseEnvVar(allocator, svc.service_name);
+                defer allocator.free(alias);
+                try env_map.put(alias, port_str);
+            }
+        }
     }
 
     // Spawn child process and wait
@@ -56,37 +80,51 @@ pub fn exec(allocator: Allocator, argv: []const []const u8, services: []const Se
 
 // --- Tests ---
 
-test "serviceNameToEnvVar: simple name" {
+test "serviceNameToEnvVar: simple name index 0" {
     const allocator = std.testing.allocator;
-    const result = try serviceNameToEnvVar(allocator, "web");
+    const result = try serviceNameToEnvVar(allocator, "web", 0);
     defer allocator.free(result);
-    try std.testing.expectEqualStrings("WEB_PORT", result);
+    try std.testing.expectEqualStrings("WEB_PORT_0", result);
 }
 
-test "serviceNameToEnvVar: name with hyphen" {
+test "serviceNameToEnvVar: name with hyphen index 1" {
     const allocator = std.testing.allocator;
-    const result = try serviceNameToEnvVar(allocator, "my-web");
+    const result = try serviceNameToEnvVar(allocator, "my-web", 1);
     defer allocator.free(result);
-    try std.testing.expectEqualStrings("MY_WEB_PORT", result);
+    try std.testing.expectEqualStrings("MY_WEB_PORT_1", result);
 }
 
 test "serviceNameToEnvVar: already uppercase" {
     const allocator = std.testing.allocator;
-    const result = try serviceNameToEnvVar(allocator, "API");
+    const result = try serviceNameToEnvVar(allocator, "API", 0);
     defer allocator.free(result);
-    try std.testing.expectEqualStrings("API_PORT", result);
+    try std.testing.expectEqualStrings("API_PORT_0", result);
 }
 
 test "serviceNameToEnvVar: mixed case with hyphens" {
     const allocator = std.testing.allocator;
-    const result = try serviceNameToEnvVar(allocator, "my-Web-App");
+    const result = try serviceNameToEnvVar(allocator, "my-Web-App", 2);
     defer allocator.free(result);
-    try std.testing.expectEqualStrings("MY_WEB_APP_PORT", result);
+    try std.testing.expectEqualStrings("MY_WEB_APP_PORT_2", result);
 }
 
 test "serviceNameToEnvVar: name with underscore" {
     const allocator = std.testing.allocator;
-    const result = try serviceNameToEnvVar(allocator, "my_db");
+    const result = try serviceNameToEnvVar(allocator, "my_db", 0);
     defer allocator.free(result);
-    try std.testing.expectEqualStrings("MY_DB_PORT", result);
+    try std.testing.expectEqualStrings("MY_DB_PORT_0", result);
+}
+
+test "serviceNameToBaseEnvVar: simple name" {
+    const allocator = std.testing.allocator;
+    const result = try serviceNameToBaseEnvVar(allocator, "web");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("WEB_PORT", result);
+}
+
+test "serviceNameToBaseEnvVar: name with hyphen" {
+    const allocator = std.testing.allocator;
+    const result = try serviceNameToBaseEnvVar(allocator, "my-web");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("MY_WEB_PORT", result);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -95,12 +95,12 @@ fn runCmd(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     const extracted_files = try compose.extractComposeFilesFromArgs(allocator, cmd_args.items);
     defer if (extracted_files) |files| allocator.free(files);
 
-    var services: []const []const u8 = &.{};
+    var services: []const compose.ServiceInfo = &.{};
     if (extracted_files) |files| {
         // Parse services from all specified compose files
-        var all_services: std.ArrayListUnmanaged([]const u8) = .{};
+        var all_services: std.ArrayListUnmanaged(compose.ServiceInfo) = .{};
         errdefer {
-            for (all_services.items) |s| allocator.free(s);
+            for (all_services.items) |s| allocator.free(s.name);
             all_services.deinit(allocator);
         }
         for (files) |file| {
@@ -150,22 +150,43 @@ fn runCmd(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     defer reserved_ports.deinit(allocator);
     for (existing_mappings) |m| {
         for (m.services) |svc| {
-            try reserved_ports.append(allocator, svc.port);
+            for (svc.ports) |p| {
+                try reserved_ports.append(allocator, p);
+            }
         }
     }
 
-    // 3. Allocate ports (avoiding reserved)
-    const ports = try port.allocatePorts(allocator, services.len, reserved_ports.items);
-    defer allocator.free(ports);
+    // 3. Allocate ports (avoiding reserved) - total count is sum of port_counts
+    var total_port_count: usize = 0;
+    for (services) |svc| {
+        total_port_count += svc.port_count;
+    }
 
+    const all_ports = try port.allocatePorts(allocator, total_port_count, reserved_ports.items);
+    defer allocator.free(all_ports);
+
+    // Build service mappings with multi-port slices
     const service_mappings = try allocator.alloc(mapping.ServiceMapping, services.len);
     defer allocator.free(service_mappings);
 
-    for (services, ports, 0..) |svc_name, svc_port, i| {
+    // Allocate port slices for each service (owned, freed at cleanup)
+    var port_slices: std.ArrayListUnmanaged([]u16) = .{};
+    defer {
+        for (port_slices.items) |s| allocator.free(s);
+        port_slices.deinit(allocator);
+    }
+
+    var port_offset: usize = 0;
+    for (services, 0..) |svc, i| {
+        const svc_ports = try allocator.alloc(u16, svc.port_count);
+        @memcpy(svc_ports, all_ports[port_offset .. port_offset + svc.port_count]);
+        try port_slices.append(allocator, svc_ports);
+
         service_mappings[i] = .{
-            .service_name = svc_name,
-            .port = svc_port,
+            .service_name = svc.name,
+            .ports = svc_ports,
         };
+        port_offset += svc.port_count;
     }
 
     const project_mapping = mapping.ProjectMapping{
@@ -185,8 +206,10 @@ fn runCmd(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     }
 
     // Print service URLs
-    for (services, ports) |svc_name, svc_port| {
-        std.debug.print("  {s}.{s}.localhost:{d} -> :{d}\n", .{ svc_name, proj_name, proxy.PROXY_PORT, svc_port });
+    for (services, service_mappings) |svc, sm| {
+        for (sm.ports, 0..) |p, idx| {
+            std.debug.print("  {d}.{s}.{s}.localhost:{d} -> :{d}\n", .{ idx, svc.name, proj_name, proxy.PROXY_PORT, p });
+        }
     }
 
     // 4. Start proxy server in background thread
@@ -197,13 +220,14 @@ fn runCmd(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     proxy_thread.detach();
 
     // 5. Set environment variables and execute command
-    const exec_services = try allocator.alloc(executor.ServicePort, services.len);
+    const exec_services = try allocator.alloc(executor.ServicePorts, services.len);
     defer allocator.free(exec_services);
 
-    for (services, ports, 0..) |svc_name, svc_port, i| {
+    for (services, service_mappings, 0..) |svc, sm, i| {
+        _ = svc;
         exec_services[i] = .{
-            .service_name = svc_name,
-            .port = svc_port,
+            .service_name = sm.service_name,
+            .ports = sm.ports,
         };
     }
 

--- a/src/mapping.zig
+++ b/src/mapping.zig
@@ -5,7 +5,7 @@ const Allocator = std.mem.Allocator;
 
 pub const ServiceMapping = struct {
     service_name: []const u8,
-    port: u16,
+    ports: []const u16,
 };
 
 pub const ProjectMapping = struct {
@@ -35,7 +35,7 @@ pub fn writeMapping(allocator: Allocator, dir: std.fs.Dir, project: ProjectMappi
     for (project.services, 0..) |svc, i| {
         json_services[i] = .{
             .service_name = svc.service_name,
-            .port = svc.port,
+            .ports = svc.ports,
         };
     }
 
@@ -99,7 +99,7 @@ fn readSingleMapping(allocator: Allocator, dir: std.fs.Dir, filename: []const u8
     for (v.services, 0..) |svc, i| {
         services[i] = .{
             .service_name = try allocator.dupe(u8, svc.service_name),
-            .port = svc.port,
+            .ports = try allocator.dupe(u16, svc.ports),
         };
     }
 
@@ -121,12 +121,13 @@ pub fn removeMapping(allocator: Allocator, dir: std.fs.Dir, project_name: []cons
     };
 }
 
-pub fn freeMappingContents(allocator: Allocator, mapping: *ProjectMapping) void {
-    for (mapping.services) |svc| {
+pub fn freeMappingContents(allocator: Allocator, m: *ProjectMapping) void {
+    for (m.services) |svc| {
         allocator.free(svc.service_name);
+        allocator.free(svc.ports);
     }
-    allocator.free(mapping.services);
-    allocator.free(mapping.project_name);
+    allocator.free(m.services);
+    allocator.free(m.project_name);
 }
 
 pub fn freeAllMappings(allocator: Allocator, mappings: []ProjectMapping) void {
@@ -139,7 +140,7 @@ pub fn freeAllMappings(allocator: Allocator, mappings: []ProjectMapping) void {
 // JSON serialization types
 const JsonService = struct {
     service_name: []const u8,
-    port: u16,
+    ports: []const u16,
 };
 
 const JsonMapping = struct {
@@ -163,9 +164,11 @@ test "writeMapping and readAllMappings round-trip" {
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const dir_path = try tmpDirPath(&tmp, &path_buf);
 
+    const web_ports = &[_]u16{ 49152, 49154 };
+    const api_ports = &[_]u16{49153};
     const services = &[_]ServiceMapping{
-        .{ .service_name = "web", .port = 49152 },
-        .{ .service_name = "api", .port = 49153 },
+        .{ .service_name = "web", .ports = web_ports },
+        .{ .service_name = "api", .ports = api_ports },
     };
 
     const project = ProjectMapping{
@@ -184,9 +187,12 @@ test "writeMapping and readAllMappings round-trip" {
     try std.testing.expectEqual(@as(i32, 12345), mappings[0].pid);
     try std.testing.expectEqual(@as(usize, 2), mappings[0].services.len);
     try std.testing.expectEqualStrings("web", mappings[0].services[0].service_name);
-    try std.testing.expectEqual(@as(u16, 49152), mappings[0].services[0].port);
+    try std.testing.expectEqual(@as(usize, 2), mappings[0].services[0].ports.len);
+    try std.testing.expectEqual(@as(u16, 49152), mappings[0].services[0].ports[0]);
+    try std.testing.expectEqual(@as(u16, 49154), mappings[0].services[0].ports[1]);
     try std.testing.expectEqualStrings("api", mappings[0].services[1].service_name);
-    try std.testing.expectEqual(@as(u16, 49153), mappings[0].services[1].port);
+    try std.testing.expectEqual(@as(usize, 1), mappings[0].services[1].ports.len);
+    try std.testing.expectEqual(@as(u16, 49153), mappings[0].services[1].ports[0]);
 }
 
 test "removeMapping deletes file" {
@@ -195,8 +201,9 @@ test "removeMapping deletes file" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
+    const web_ports = &[_]u16{8080};
     const services = &[_]ServiceMapping{
-        .{ .service_name = "web", .port = 8080 },
+        .{ .service_name = "web", .ports = web_ports },
     };
 
     const project = ProjectMapping{

--- a/src/proxy.zig
+++ b/src/proxy.zig
@@ -9,10 +9,13 @@ pub const PROXY_PORT: u16 = 7355;
 pub const HostInfo = struct {
     service: []const u8,
     project: []const u8,
+    port_index: usize,
 };
 
-/// Extract project_name and service_name from the Host header.
-/// Format: <service_name>.<project_name>.localhost[:port]
+/// Extract project_name, service_name and optional port index from the Host header.
+/// Formats:
+///   <service_name>.<project_name>.localhost[:port]           -> port_index = 0
+///   <index>.<service_name>.<project_name>.localhost[:port]   -> port_index = index
 pub fn parseHost(host: []const u8) ?HostInfo {
     // Strip port if present
     const host_without_port = if (std.mem.indexOfScalar(u8, host, ':')) |colon_idx|
@@ -27,22 +30,44 @@ pub fn parseHost(host: []const u8) ?HostInfo {
     const prefix = host_without_port[0 .. host_without_port.len - suffix.len];
     if (prefix.len == 0) return null;
 
-    // Find the first dot: <service>.<project>
-    const dot_idx = std.mem.indexOfScalar(u8, prefix, '.') orelse return null;
-    if (dot_idx == 0 or dot_idx == prefix.len - 1) return null;
+    // Find the first dot
+    const first_dot = std.mem.indexOfScalar(u8, prefix, '.') orelse return null;
+    if (first_dot == 0 or first_dot == prefix.len - 1) return null;
 
-    return HostInfo{
-        .service = prefix[0..dot_idx],
-        .project = prefix[dot_idx + 1 ..],
-    };
+    const first_part = prefix[0..first_dot];
+    const rest = prefix[first_dot + 1 ..];
+
+    // Try to parse first_part as a port index number
+    if (std.fmt.parseInt(usize, first_part, 10)) |port_index| {
+        // Format: <index>.<service>.<project>.localhost
+        // rest must contain at least <service>.<project>
+        const second_dot = std.mem.indexOfScalar(u8, rest, '.') orelse return null;
+        if (second_dot == 0 or second_dot == rest.len - 1) return null;
+
+        return HostInfo{
+            .service = rest[0..second_dot],
+            .project = rest[second_dot + 1 ..],
+            .port_index = port_index,
+        };
+    } else |_| {
+        // Format: <service>.<project>.localhost
+        return HostInfo{
+            .service = first_part,
+            .project = rest,
+            .port_index = 0,
+        };
+    }
 }
 
-/// Look up the backend port from mappings by project and service name.
-fn findBackendPort(mappings: []const mapping.ProjectMapping, project: []const u8, service: []const u8) ?u16 {
+/// Look up the backend port from mappings by project, service name, and port index.
+fn findBackendPort(mappings: []const mapping.ProjectMapping, project: []const u8, service: []const u8, port_index: usize) ?u16 {
     for (mappings) |m| {
         if (!std.mem.eql(u8, m.project_name, project)) continue;
         for (m.services) |svc| {
-            if (std.mem.eql(u8, svc.service_name, service)) return svc.port;
+            if (std.mem.eql(u8, svc.service_name, service)) {
+                if (port_index < svc.ports.len) return svc.ports[port_index];
+                return null;
+            }
         }
     }
     return null;
@@ -213,7 +238,7 @@ fn handleClient(allocator: Allocator, client_fd: posix.socket_t, mapping_dir_pat
     const mappings = try mapping.readAllMappings(allocator, mapping_dir_path);
     defer mapping.freeAllMappings(allocator, mappings);
 
-    const backend_port = findBackendPort(mappings, host_info.project, host_info.service) orelse {
+    const backend_port = findBackendPort(mappings, host_info.project, host_info.service, host_info.port_index) orelse {
         sendErrorResponse(client_fd, "404 Not Found", "Service not found");
         return;
     };
@@ -227,12 +252,35 @@ test "parseHost: valid host" {
     const result = parseHost("web.myapp.localhost:7355").?;
     try std.testing.expectEqualStrings("web", result.service);
     try std.testing.expectEqualStrings("myapp", result.project);
+    try std.testing.expectEqual(@as(usize, 0), result.port_index);
 }
 
 test "parseHost: without port" {
     const result = parseHost("api.backend.localhost").?;
     try std.testing.expectEqualStrings("api", result.service);
     try std.testing.expectEqualStrings("backend", result.project);
+    try std.testing.expectEqual(@as(usize, 0), result.port_index);
+}
+
+test "parseHost: with port index" {
+    const result = parseHost("0.web.myapp.localhost:7355").?;
+    try std.testing.expectEqualStrings("web", result.service);
+    try std.testing.expectEqualStrings("myapp", result.project);
+    try std.testing.expectEqual(@as(usize, 0), result.port_index);
+}
+
+test "parseHost: with port index 1" {
+    const result = parseHost("1.web.myapp.localhost:7355").?;
+    try std.testing.expectEqualStrings("web", result.service);
+    try std.testing.expectEqualStrings("myapp", result.project);
+    try std.testing.expectEqual(@as(usize, 1), result.port_index);
+}
+
+test "parseHost: with port index and multi-level project" {
+    const result = parseHost("2.api.my.app.localhost").?;
+    try std.testing.expectEqualStrings("api", result.service);
+    try std.testing.expectEqualStrings("my.app", result.project);
+    try std.testing.expectEqual(@as(usize, 2), result.port_index);
 }
 
 test "parseHost: just localhost" {
@@ -240,7 +288,6 @@ test "parseHost: just localhost" {
 }
 
 test "parseHost: single component before localhost" {
-    // "web.localhost" has no project
     try std.testing.expect(parseHost("web.localhost") == null);
 }
 
@@ -256,37 +303,57 @@ test "parseHost: multi-level project name" {
     const result = parseHost("web.my.app.localhost:7355").?;
     try std.testing.expectEqualStrings("web", result.service);
     try std.testing.expectEqualStrings("my.app", result.project);
+    try std.testing.expectEqual(@as(usize, 0), result.port_index);
 }
 
-test "findBackendPort: found" {
+test "findBackendPort: found index 0" {
+    const web_ports = &[_]u16{ 49152, 49154 };
+    const api_ports = &[_]u16{49153};
     const mappings = &[_]mapping.ProjectMapping{
         .{
             .project_name = "myapp",
             .pid = 123,
             .services = &[_]mapping.ServiceMapping{
-                .{ .service_name = "web", .port = 49152 },
-                .{ .service_name = "api", .port = 49153 },
+                .{ .service_name = "web", .ports = web_ports },
+                .{ .service_name = "api", .ports = api_ports },
             },
         },
     };
 
-    try std.testing.expectEqual(@as(?u16, 49152), findBackendPort(mappings, "myapp", "web"));
-    try std.testing.expectEqual(@as(?u16, 49153), findBackendPort(mappings, "myapp", "api"));
+    try std.testing.expectEqual(@as(?u16, 49152), findBackendPort(mappings, "myapp", "web", 0));
+    try std.testing.expectEqual(@as(?u16, 49154), findBackendPort(mappings, "myapp", "web", 1));
+    try std.testing.expectEqual(@as(?u16, 49153), findBackendPort(mappings, "myapp", "api", 0));
+}
+
+test "findBackendPort: index out of range" {
+    const web_ports = &[_]u16{49152};
+    const mappings = &[_]mapping.ProjectMapping{
+        .{
+            .project_name = "myapp",
+            .pid = 123,
+            .services = &[_]mapping.ServiceMapping{
+                .{ .service_name = "web", .ports = web_ports },
+            },
+        },
+    };
+
+    try std.testing.expectEqual(@as(?u16, null), findBackendPort(mappings, "myapp", "web", 1));
 }
 
 test "findBackendPort: not found" {
+    const web_ports = &[_]u16{49152};
     const mappings = &[_]mapping.ProjectMapping{
         .{
             .project_name = "myapp",
             .pid = 123,
             .services = &[_]mapping.ServiceMapping{
-                .{ .service_name = "web", .port = 49152 },
+                .{ .service_name = "web", .ports = web_ports },
             },
         },
     };
 
-    try std.testing.expectEqual(@as(?u16, null), findBackendPort(mappings, "myapp", "db"));
-    try std.testing.expectEqual(@as(?u16, null), findBackendPort(mappings, "other", "web"));
+    try std.testing.expectEqual(@as(?u16, null), findBackendPort(mappings, "myapp", "db", 0));
+    try std.testing.expectEqual(@as(?u16, null), findBackendPort(mappings, "other", "web", 0));
 }
 
 test "extractHostHeader: standard header" {


### PR DESCRIPTION
## Summary
- Each compose service now allocates N ports based on its `ports` field count, issuing `SERVICE_PORT_0`, `SERVICE_PORT_1`, ... environment variables
- `SERVICE_PORT` is preserved as a backward-compatible alias for `SERVICE_PORT_0`
- Proxy routing supports `<index>.<service>.<project>.localhost` to access specific port indices (defaults to port 0 without index prefix)

## Test plan
- [x] All existing tests updated and passing
- [x] New tests for multi-port compose parsing, indexed env var generation, and index-based host routing
- [ ] Manual test: run with a compose file containing multiple ports per service, verify env vars and proxy routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)