### PR TITLE
fix(cli): omit port index prefix from URL for index 0

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -208,7 +208,11 @@ fn runCmd(allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     // Print service URLs
     for (services, service_mappings) |svc, sm| {
         for (sm.ports, 0..) |p, idx| {
-            std.debug.print("  {d}.{s}.{s}.localhost:{d} -> :{d}\n", .{ idx, svc.name, proj_name, proxy.PROXY_PORT, p });
+            if (idx == 0) {
+                std.debug.print("  {s}.{s}.localhost:{d} -> :{d}\n", .{ svc.name, proj_name, proxy.PROXY_PORT, p });
+            } else {
+                std.debug.print("  {d}.{s}.{s}.localhost:{d} -> :{d}\n", .{ idx, svc.name, proj_name, proxy.PROXY_PORT, p });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Display `web.project.localhost` instead of `0.web.project.localhost` for port index 0
- Only show numeric prefix for index 1 and above (e.g. `1.web.project.localhost`)

## Test plan
- [x] Verified with multi-port example: index 0 shows `web.multi-port.localhost`, index 1 shows `1.web.multi-port.localhost`
- [x] Verified single-port examples still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)