### PR TITLE
docs(skill): update verifying-dockportless for post-v0.1.0 features

### DIFF
--- a/skills/verifying-dockportless/SKILL.md
+++ b/skills/verifying-dockportless/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verifying-dockportless
-description: Launches and verifies local dev environments using dockportless with worktree-unique project names. Use when starting docker compose services, checking service accessibility via proxy, or when developing across multiple git worktrees to avoid port collisions.
+description: Launches and verifies local dev environments using dockportless with worktree-unique project names. Use when starting docker compose services, checking service accessibility via proxy, enabling TLS/HTTPS routing, or when developing across multiple git worktrees to avoid port collisions.
 ---
 
 # Verifying with dockportless
@@ -15,22 +15,33 @@ Use this skill when you need to start a local development environment with `dock
 PROJECT_NAME="$(basename "$(git rev-parse --show-toplevel)" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')"
 ```
 
-### 2. Start services
+### 2. (If needed) Enable TLS routing
+
+**Skip this step** for HTTP-only services (web apps, REST APIs, etc.).
+
+Run once per machine **only when**:
+- Connecting directly to **PostgreSQL**, **Redis**, or **MongoDB** via dockportless proxy (these protocols require TLS for hostname-based routing)
+- Accessing services over **HTTPS**
+
+```bash
+sudo dockportless trust
+```
+
+### 3. Start services
 
 ```bash
 dockportless run "$PROJECT_NAME" docker compose up -d
 ```
 
-### 3. Access services
+### 4. Access services
 
 Each service is available at `<service>.<project_name>.localhost:7355`:
 
 ```bash
 curl http://web.$PROJECT_NAME.localhost:7355/
-curl http://api.$PROJECT_NAME.localhost:7355/
 ```
 
-### 4. Verify
+### 5. Verify
 
 ```bash
 # Check HTTP response
@@ -53,7 +64,9 @@ Each gets its own allocated ports and its own proxy routes.
 
 ## Compose File Setup
 
-Services must use environment variable substitution for ports so dockportless can inject allocated ports:
+Services must use environment variable substitution for ports so dockportless can inject allocated ports.
+
+### Single-port services
 
 ```yaml
 services:
@@ -69,13 +82,51 @@ services:
 
 dockportless sets `WEB_PORT` and `API_PORT` automatically. Without dockportless, the defaults (8080, 3000) are used.
 
+### Multi-port services
+
+When a service exposes multiple ports, use indexed environment variables:
+
+```yaml
+services:
+  web:
+    image: myapp
+    ports:
+      - "${WEB_PORT_0:-8080}:8080"   # HTTP
+      - "${WEB_PORT_1:-8443}:8443"   # HTTPS backend
+```
+
+- `WEB_PORT` is an alias for `WEB_PORT_0` (backward-compatible)
+- URL for index 0: `web.myapp.localhost:7355` (no prefix)
+- URL for index 1+: `1.web.myapp.localhost:7355`
+
+## TLS SNI Routing (requires `dockportless trust`)
+
+dockportless auto-detects the protocol of incoming connections:
+
+- **HTTP** — Routed by `Host` header. **No TLS setup needed.**
+- **TLS (HTTPS, Redis, MongoDB, etc.)** — Routed by SNI hostname with TLS termination
+- **PostgreSQL SSL** — Detects `SSLRequest`, upgrades to TLS, then routes by SNI
+
+TLS is required for non-HTTP TCP protocols because dockportless needs a hostname to route to the correct backend. These protocols don't send a hostname in plaintext like HTTP's `Host` header, so TLS SNI is the only way to identify the target service.
+
+**When you need TLS:**
+
+| Use case | Example | `trust` needed? |
+|----------|---------|-----------------|
+| Web app via HTTP | `curl http://web.myapp.localhost:7355/` | No |
+| Web app via HTTPS | `curl https://web.myapp.localhost:7355/` | **Yes** |
+| PostgreSQL | `psql "host=db.myapp.localhost port=7355 sslmode=require"` | **Yes** |
+| Redis | `redli --tls -h cache.myapp.localhost -p 7355` | **Yes** |
+| MongoDB | `mongosh "mongodb://db.myapp.localhost:7355/?tls=true"` | **Yes** |
+
 ## Workflow
 
 1. **Derive project name** from worktree root (see above)
-2. **Start** with `dockportless run "$PROJECT_NAME" <compose-command>`
-3. **Verify** services respond at `<service>.$PROJECT_NAME.localhost:7355`
-4. **Develop** - make code changes, rebuild containers as needed
-5. **Stop** - `docker compose down` (dockportless cleans up mapping on exit)
+2. **(If needed) Trust CA** with `sudo dockportless trust` — only for HTTPS, PostgreSQL, Redis, MongoDB access
+3. **Start** with `dockportless run "$PROJECT_NAME" <compose-command>`
+4. **Verify** services respond at `<service>.$PROJECT_NAME.localhost:7355`
+5. **Develop** - make code changes, rebuild containers as needed
+6. **Stop** - `docker compose down` (dockportless cleans up mapping on exit)
 
 ## Reference
 

--- a/skills/verifying-dockportless/SKILL.md
+++ b/skills/verifying-dockportless/SKILL.md
@@ -64,60 +64,11 @@ Each gets its own allocated ports and its own proxy routes.
 
 ## Compose File Setup
 
-Services must use environment variable substitution for ports so dockportless can inject allocated ports.
-
-### Single-port services
-
-```yaml
-services:
-  web:
-    image: nginx
-    ports:
-      - "${WEB_PORT:-8080}:80"
-  api:
-    build: .
-    ports:
-      - "${API_PORT:-3000}:3000"
-```
-
-dockportless sets `WEB_PORT` and `API_PORT` automatically. Without dockportless, the defaults (8080, 3000) are used.
-
-### Multi-port services
-
-When a service exposes multiple ports, use indexed environment variables:
-
-```yaml
-services:
-  web:
-    image: myapp
-    ports:
-      - "${WEB_PORT_0:-8080}:8080"   # HTTP
-      - "${WEB_PORT_1:-8443}:8443"   # HTTPS backend
-```
-
-- `WEB_PORT` is an alias for `WEB_PORT_0` (backward-compatible)
-- URL for index 0: `web.myapp.localhost:7355` (no prefix)
-- URL for index 1+: `1.web.myapp.localhost:7355`
+Services must use `${SERVICE_PORT:-default}` pattern in ports. See [COMPOSE-SETUP.md](references/COMPOSE-SETUP.md) for single-port, multi-port examples, and env var naming rules.
 
 ## TLS SNI Routing (requires `dockportless trust`)
 
-dockportless auto-detects the protocol of incoming connections:
-
-- **HTTP** — Routed by `Host` header. **No TLS setup needed.**
-- **TLS (HTTPS, Redis, MongoDB, etc.)** — Routed by SNI hostname with TLS termination
-- **PostgreSQL SSL** — Detects `SSLRequest`, upgrades to TLS, then routes by SNI
-
-TLS is required for non-HTTP TCP protocols because dockportless needs a hostname to route to the correct backend. These protocols don't send a hostname in plaintext like HTTP's `Host` header, so TLS SNI is the only way to identify the target service.
-
-**When you need TLS:**
-
-| Use case | Example | `trust` needed? |
-|----------|---------|-----------------|
-| Web app via HTTP | `curl http://web.myapp.localhost:7355/` | No |
-| Web app via HTTPS | `curl https://web.myapp.localhost:7355/` | **Yes** |
-| PostgreSQL | `psql "host=db.myapp.localhost port=7355 sslmode=require"` | **Yes** |
-| Redis | `redli --tls -h cache.myapp.localhost -p 7355` | **Yes** |
-| MongoDB | `mongosh "mongodb://db.myapp.localhost:7355/?tls=true"` | **Yes** |
+**Not needed for HTTP-only services.** Required only for HTTPS, PostgreSQL, Redis, or MongoDB direct access. See [TLS-ROUTING.md](references/TLS-ROUTING.md) for protocol details, decision table, and client examples.
 
 ## Workflow
 
@@ -130,5 +81,7 @@ TLS is required for non-HTTP TCP protocols because dockportless needs a hostname
 
 ## Reference
 
+- [COMPOSE-SETUP.md](references/COMPOSE-SETUP.md) - Compose file examples (single-port, multi-port, env var naming)
+- [TLS-ROUTING.md](references/TLS-ROUTING.md) - TLS SNI protocol details, decision table, client examples
 - [VERIFICATION-GUIDE.md](references/VERIFICATION-GUIDE.md) - Detailed verification steps, multi-worktree scenarios, and troubleshooting
 - [AFTER-RESTART.md](references/AFTER-RESTART.md) - Recovering proxy routing after a machine restart

--- a/skills/verifying-dockportless/references/AFTER-RESTART.md
+++ b/skills/verifying-dockportless/references/AFTER-RESTART.md
@@ -26,3 +26,7 @@ After a restart, the mappings already exist. You only need:
 
 1. **`dockportless proxy`** — to restart the proxy that routes requests based on existing mappings
 2. **`docker compose up -d`** — to bring containers back up (they retain their port configuration)
+
+## TLS After Restart
+
+The CA certificate installed by `sudo dockportless trust` persists across restarts — no need to re-run. TLS routing resumes automatically when the proxy starts, as long as the generated certificates exist in `$XDG_DATA_HOME/dockportless/certs/`.

--- a/skills/verifying-dockportless/references/AFTER-RESTART.md
+++ b/skills/verifying-dockportless/references/AFTER-RESTART.md
@@ -29,4 +29,4 @@ After a restart, the mappings already exist. You only need:
 
 ## TLS After Restart
 
-The CA certificate installed by `sudo dockportless trust` persists across restarts — no need to re-run. TLS routing resumes automatically when the proxy starts, as long as the generated certificates exist in `$XDG_DATA_HOME/dockportless/certs/`.
+The CA certificate persists across restarts — no need to re-run `sudo dockportless trust`. See [TLS-ROUTING.md](TLS-ROUTING.md) for details.

--- a/skills/verifying-dockportless/references/COMPOSE-SETUP.md
+++ b/skills/verifying-dockportless/references/COMPOSE-SETUP.md
@@ -1,0 +1,45 @@
+# Compose File Setup
+
+Services must use environment variable substitution for ports so dockportless can inject allocated ports.
+
+## Single-port services
+
+```yaml
+services:
+  web:
+    image: nginx
+    ports:
+      - "${WEB_PORT:-8080}:80"
+  api:
+    build: .
+    ports:
+      - "${API_PORT:-3000}:3000"
+```
+
+dockportless sets `WEB_PORT` and `API_PORT` automatically. Without dockportless, the defaults (8080, 3000) are used.
+
+## Multi-port services
+
+When a service exposes multiple ports, use indexed environment variables:
+
+```yaml
+services:
+  web:
+    image: myapp
+    ports:
+      - "${WEB_PORT_0:-8080}:8080"   # HTTP
+      - "${WEB_PORT_1:-8443}:8443"   # HTTPS backend
+```
+
+- `WEB_PORT` is an alias for `WEB_PORT_0` (backward-compatible)
+- URL for index 0: `web.myapp.localhost:7355` (no prefix)
+- URL for index 1+: `1.web.myapp.localhost:7355`
+
+## Environment variable naming
+
+| Service name | Port count | Environment variables |
+|-------------|-----------|----------------------|
+| `web` | 1 | `WEB_PORT` (= `WEB_PORT_0`) |
+| `web` | 2 | `WEB_PORT` (= `WEB_PORT_0`), `WEB_PORT_1` |
+| `my-api` | 1 | `MY_API_PORT` (= `MY_API_PORT_0`) |
+| `db` | 1 | `DB_PORT` (= `DB_PORT_0`) |

--- a/skills/verifying-dockportless/references/TLS-ROUTING.md
+++ b/skills/verifying-dockportless/references/TLS-ROUTING.md
@@ -1,0 +1,61 @@
+# TLS SNI Routing
+
+dockportless auto-detects the protocol of incoming connections:
+
+- **HTTP** — Routed by `Host` header. **No TLS setup needed.**
+- **TLS (HTTPS, Redis, MongoDB, etc.)** — Routed by SNI hostname with TLS termination
+- **PostgreSQL SSL** — Detects `SSLRequest`, upgrades to TLS, then routes by SNI
+
+TLS is required for non-HTTP TCP protocols because dockportless needs a hostname to route to the correct backend. These protocols don't send a hostname in plaintext like HTTP's `Host` header, so TLS SNI is the only way to identify the target service.
+
+## When you need `dockportless trust`
+
+| Use case | Example | `trust` needed? |
+|----------|---------|-----------------|
+| Web app via HTTP | `curl http://web.myapp.localhost:7355/` | No |
+| Web app via HTTPS | `curl https://web.myapp.localhost:7355/` | **Yes** |
+| PostgreSQL | `psql "host=db.myapp.localhost port=7355 sslmode=require"` | **Yes** |
+| Redis | `redli --tls -h cache.myapp.localhost -p 7355` | **Yes** |
+| MongoDB | `mongosh "mongodb://db.myapp.localhost:7355/?tls=true"` | **Yes** |
+
+## Setup
+
+Run once per machine:
+
+```bash
+sudo dockportless trust
+```
+
+Supported trust stores:
+- **Linux**: Debian/Ubuntu, RHEL/Fedora, Arch Linux, SUSE
+- **macOS**: System Keychain
+
+## Client examples
+
+### HTTPS
+
+```bash
+curl https://web.myapp.localhost:7355/
+```
+
+### PostgreSQL SSL
+
+```bash
+psql "host=db.myapp.localhost port=7355 sslmode=require"
+```
+
+### Redis TLS
+
+```bash
+redli --tls -h cache.myapp.localhost -p 7355
+```
+
+### MongoDB TLS
+
+```bash
+mongosh "mongodb://db.myapp.localhost:7355/?tls=true"
+```
+
+## After restart
+
+The CA certificate persists across restarts — no need to re-run `sudo dockportless trust`. TLS routing resumes automatically when the proxy starts, as long as the generated certificates exist in `$XDG_DATA_HOME/dockportless/certs/`.

--- a/skills/verifying-dockportless/references/VERIFICATION-GUIDE.md
+++ b/skills/verifying-dockportless/references/VERIFICATION-GUIDE.md
@@ -7,6 +7,7 @@ Detailed procedures for verifying that your local dev environment is running cor
 - `dockportless` installed and available in PATH
 - Docker and Docker Compose (or compatible tool) running
 - Compose file with `${SERVICE_PORT:-default}` port substitution pattern
+- `sudo dockportless trust` run once — **only if** connecting to PostgreSQL/Redis/MongoDB directly or using HTTPS
 
 ## Single Worktree Verification
 
@@ -29,12 +30,47 @@ dockportless run "$PROJECT_NAME" docker compose up -d
 # List services from compose file
 SERVICES=$(docker compose config --services)
 
-# Check each service
+# Check each service via HTTP
 for SVC in $SERVICES; do
   STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
     "http://${SVC}.${PROJECT_NAME}.localhost:7355/" --max-time 5 2>/dev/null || echo "000")
   echo "$SVC: HTTP $STATUS"
 done
+```
+
+### Step 4: Verify TLS routing (only for HTTPS / direct DB access)
+
+This step is **only needed** when:
+- Accessing services over HTTPS
+- Connecting directly to PostgreSQL, Redis, or MongoDB via dockportless proxy
+
+Skip for HTTP-only web services.
+
+```bash
+# Check HTTPS (requires prior `sudo dockportless trust`)
+for SVC in $SERVICES; do
+  STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+    "https://${SVC}.${PROJECT_NAME}.localhost:7355/" --max-time 5 2>/dev/null || echo "000")
+  echo "$SVC: HTTPS $STATUS"
+done
+
+# Check PostgreSQL SSL
+psql "host=db.${PROJECT_NAME}.localhost port=7355 sslmode=require" -c "SELECT 1"
+
+# Check Redis TLS
+redli --tls -h cache.${PROJECT_NAME}.localhost -p 7355 PING
+```
+
+## Multi-Port Verification
+
+When a service exposes multiple ports, verify each port index:
+
+```bash
+# Index 0 (no prefix)
+curl http://web.${PROJECT_NAME}.localhost:7355/
+
+# Index 1+
+curl http://1.web.${PROJECT_NAME}.localhost:7355/
 ```
 
 ## Multi-Worktree Parallel Verification
@@ -89,3 +125,17 @@ Service names in the URL must match exactly what's defined under `services:` in 
 ```bash
 docker compose config --services
 ```
+
+### TLS/HTTPS not working (for HTTPS, PostgreSQL, Redis, MongoDB)
+
+1. Ensure `sudo dockportless trust` has been run at least once. Not needed for HTTP-only services.
+2. Check that the CA certificate was installed successfully (no errors from the trust command).
+3. Some clients may need to be restarted to pick up the new CA certificate.
+
+### Multi-port URL not resolving
+
+For services with multiple ports, index 0 uses no prefix (`web.myapp.localhost`), while index 1+ uses a numeric prefix (`1.web.myapp.localhost`). Ensure:
+
+1. The compose file lists ports in the correct order.
+2. Environment variables use the indexed form: `${WEB_PORT_0:-8080}`, `${WEB_PORT_1:-8443}`.
+3. `WEB_PORT` (without index) is an alias for `WEB_PORT_0` and works for single-port services.


### PR DESCRIPTION
## Summary
- Update `verifying-dockportless` agent skill to reflect features added since v0.1.0
- Add multi-port support docs (indexed env vars `WEB_PORT_0`/`WEB_PORT_1`, indexed URLs)
- Add TLS SNI routing section with clear guidance on when `dockportless trust` is needed vs not
- Add PostgreSQL SSL, Redis TLS, MongoDB TLS verification examples
- Add TLS persistence note to AFTER-RESTART.md
- Add multi-port and TLS troubleshooting entries

## Test plan
- [ ] Verify SKILL.md renders correctly and Quick Start flow is clear
- [ ] Confirm `dockportless trust` step clearly indicates it should be skipped for HTTP-only services
- [ ] Check multi-port compose example uses correct env var naming (`WEB_PORT_0`, `WEB_PORT_1`)
- [ ] Verify TLS decision table covers all documented use cases (HTTP, HTTPS, PostgreSQL, Redis, MongoDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)