### PR TITLE
ci: add skills-ref validation to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Run tests
         run: zig build test
 
+  validate-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Validate skills
+        run: uvx --from 'skills-ref @ git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref' skills-ref validate skills/*
+
   build:
     runs-on: ubuntu-latest
     needs: [lint, test]


### PR DESCRIPTION
## Summary
- Add `validate-skills` job to CI workflow that runs `skills-ref validate` against all skill directories
- Uses `uvx` with `astral-sh/setup-uv` to run skills-ref directly from the agentskills repository without manual Python environment setup

## Test plan
- [x] Verify `validate-skills` job passes on CI
- [x] Confirm existing CI jobs (lint, test, build) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)