### PR TITLE
fix(build): use ReleaseFast for OpenSSL to avoid UBSan crash

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,9 +6,12 @@ pub fn build(b: *std.Build) void {
 
     const clap = b.dependency("clap", .{});
     const zig_yaml = b.dependency("zig_yaml", .{});
+    // OpenSSL uses function pointer casts (e.g. OPENSSL_sk_pop_free) that are
+    // technically undefined behavior in C. ReleaseSafe enables UBSan which
+    // traps on these, so always build OpenSSL with ReleaseFast.
     const openssl = b.dependency("openssl", .{
         .target = target,
-        .optimize = optimize,
+        .optimize = .ReleaseFast,
     });
 
     const root_module = b.createModule(.{


### PR DESCRIPTION
## Summary
- OpenSSL's `OPENSSL_sk_pop_free` casts generic `void(*)(void*)` function pointers to type-specific free functions, which is undefined behavior in C
- Zig's `ReleaseSafe` mode enables UBSan, which inserts `ud1` trap instructions at these cast sites, causing `SIGILL` during `SSL_CTX_new` initialization
- Fix by pinning OpenSSL dependency to `ReleaseFast` while keeping `ReleaseSafe` for the rest of the codebase

## Test plan
- [x] `zig build -Doptimize=ReleaseSafe` succeeds
- [x] `dockportless run postgres-ssl docker compose up` no longer crashes with `Illegal instruction`
- [x] Proxy starts successfully with `HTTP + TLS` mode
- [x] All unit tests pass (`zig build test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)